### PR TITLE
Support to change message's icon emoji

### DIFF
--- a/main.go
+++ b/main.go
@@ -131,6 +131,10 @@ func main() {
 			Name:  "username, u",
 			Usage: "Stream messages as given bot user. Defaults to auth user",
 		},
+		cli.StringFlag{
+			Name:  "iconemoji, i",
+			Usage: "Stream messages as given bot icon emoji. Defaults to auth user's icon",
+		},
 	}
 
 	app.Action = func(c *cli.Context) {
@@ -150,6 +154,7 @@ func main() {
 
 		noop = c.Bool("noop")
 		username := c.String("username")
+		iconEmoji := c.String("iconemoji")
 		fileName := c.String("filename")
 		fileType := c.String("filetype")
 		fileComment := c.String("comment")
@@ -160,7 +165,7 @@ func main() {
 		}
 
 		InitAPI(token)
-		slackcat := newSlackcat(username, channel)
+		slackcat := newSlackcat(username, iconEmoji, channel)
 
 		if c.Bool("list") {
 			fmt.Println("channels:")

--- a/slackcat.go
+++ b/slackcat.go
@@ -16,15 +16,17 @@ type Slackcat struct {
 	queue       *StreamQ
 	shutdown    chan os.Signal
 	username    string
+	iconEmoji   string
 	channelID   string
 	channelName string
 }
 
-func newSlackcat(username, channelname string) *Slackcat {
+func newSlackcat(username, iconEmoji, channelname string) *Slackcat {
 	sc := &Slackcat{
 		queue:       newStreamQ(),
 		shutdown:    make(chan os.Signal, 1),
 		username:    username,
+		iconEmoji:   iconEmoji,
 		channelName: channelname,
 	}
 
@@ -97,6 +99,9 @@ func (sc *Slackcat) postMsg(msglines []string) {
 	if sc.username != "" {
 		msgOpts.AsUser = false
 		msgOpts.Username = sc.username
+	}
+	if sc.iconEmoji != "" {
+		msgOpts.IconEmoji = sc.iconEmoji
 	}
 
 	err := api.ChatPostMessage(sc.channelID, msg, msgOpts)


### PR DESCRIPTION
Support to change message's icon by iconemoji parameter.

Usage:

```bash
echo "wow" | slackcat -i ":+1:" -c my-channel -u yasuhiroki --stream
```

In Slack,

![image](https://user-images.githubusercontent.com/3108110/44900546-d0a7c180-ad3f-11e8-8a98-f9411fe3ea66.png)
