### PR TITLE
Fix build error in slackcat.go

### DIFF
--- a/slackcat.go
+++ b/slackcat.go
@@ -122,7 +122,7 @@ func (sc *Slackcat) postFile(filePath, fileName, fileType, fileComment string) {
 	}
 
 	start := time.Now()
-	err := api.FilesUpload(&slack.FilesUploadOpt{
+	_, err := api.FilesUpload(&slack.FilesUploadOpt{
 		Filepath:       filePath,
 		Filename:       fileName,
 		Filetype:       fileType,


### PR DESCRIPTION
Now, `make build` occur error like following,

```bash
$ make build
dep ensure
CGO_ENABLED=0 go build -ldflags "-s -X main.version=1.5 -X main.build=94935f1" -o slackcat
# github.com/bcicen/slackcat
./slackcat.go:125:24: multiple-value api.FilesUpload() in single-value context
make: *** [build] Error 2
```

The line seems to need additional variable, because `api.FilesUpload` function returns two values.