### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/config.go
+++ b/config.go
@@ -20,14 +20,14 @@ type Config struct {
 	DefaultChannel string            `toml:"default_channel"`
 }
 
-// Return new default config
+// NewConfig returns new default config
 func NewConfig() *Config {
 	return &Config{
 		Teams: make(map[string]string),
 	}
 }
 
-// Return config read from file
+// ReadConfig returns config read from file
 func ReadConfig(path string) *Config {
 	config := NewConfig()
 	lines, err := readLines(path)

--- a/queue.go
+++ b/queue.go
@@ -28,7 +28,7 @@ func (q *StreamQ) Add(line string) {
 	q.lock.Unlock()
 }
 
-// return all lines in queue
+// Flush returns all lines in queue
 func (q *StreamQ) Flush() []string {
 	q.lock.Lock()
 	defer q.lock.Unlock()


### PR DESCRIPTION
Hi, we updated some exported function comments based on best practices from Effective Go. It’s admittedly a relatively minor fix up. Does this help you?